### PR TITLE
Added a 'time-to-station' parameter

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -13,8 +13,6 @@ const showError = (err) => {
 	process.exit(1)
 }
 
-
-
 const argv = mri(process.argv.slice(2), {
 	boolean: ['help', 'h']
 })
@@ -36,8 +34,6 @@ if (argv._[0] === 'init') {
 	argv._[3] ? conf.set('time-to-station', argv._[3]) : conf.set('time-to-station', 0)
 	process.exit(0)
 }
-
-
 
 const stationId = process.env.STATION_ID || conf.get('station-id')
 const nextStationId = process.env.NEXT_STATION_ID || conf.get('next-station-id')

--- a/bin.js
+++ b/bin.js
@@ -23,6 +23,11 @@ if (argv.help || argv.h) {
 Usage:
     vbb-anybar
     vbb-anybar init <station-id> <next-station-id> [<time-to-station>]
+
+Arguments:
+    station-id      	Station number (e.g. 900000023201)
+    next-station-id 	Station number (e.g. 900000023201)
+	time-to-station		Travel time to station in minutes (optional)
 \n`)
 	process.exit()
 }
@@ -31,13 +36,13 @@ if (argv._[0] === 'init') {
 	if (!argv._[1] || !argv._[2]) showError('Missing arguments.')
 	conf.set('station-id', argv._[1])
 	conf.set('next-station-id', argv._[2])
-	argv._[3] ? conf.set('time-to-station', argv._[3]) : conf.set('time-to-station', 0)
+	conf.set('time-to-station', argv._[3] || 0)
 	process.exit(0)
 }
 
 const stationId = process.env.STATION_ID || conf.get('station-id')
 const nextStationId = process.env.NEXT_STATION_ID || conf.get('next-station-id')
-const timeToStation = process.env.TIME_TO_STATION || conf.get('time-to-station') || 0
+const timeToStation = parseInt(process.env.TIME_TO_STATION || conf.get('time-to-station') || 0, 10)
 
 update(stationId, nextStationId, timeToStation)
 .catch(showError)

--- a/bin.js
+++ b/bin.js
@@ -24,7 +24,7 @@ if (argv.help || argv.h) {
 	process.stdout.write(`
 Usage:
     vbb-anybar
-    vbb-anybar init <station-id> <next-station-id>
+    vbb-anybar init <station-id> <next-station-id> [<time-to-station>]
 \n`)
 	process.exit()
 }
@@ -33,6 +33,7 @@ if (argv._[0] === 'init') {
 	if (!argv._[1] || !argv._[2]) showError('Missing arguments.')
 	conf.set('station-id', argv._[1])
 	conf.set('next-station-id', argv._[2])
+	argv._[3] ? conf.set('time-to-station', argv._[3]) : conf.set('time-to-station', 0)
 	process.exit(0)
 }
 
@@ -40,6 +41,7 @@ if (argv._[0] === 'init') {
 
 const stationId = process.env.STATION_ID || conf.get('station-id')
 const nextStationId = process.env.NEXT_STATION_ID || conf.get('next-station-id')
+const timeToStation = process.env.TIME_TO_STATION || conf.get('time-to-station') || 0
 
-update(stationId, nextStationId)
+update(stationId, nextStationId, timeToStation)
 .catch(showError)

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ const colors = [
 ]
 const minute = 1000 * 60
 
-module.exports = (from, to) => {
+module.exports = (from, to, timeToStation) => {
 	return depsInDirection(from, to)
 	.then((deps) => {
 		const dep = deps[0]
 
-		const i = Math.floor((new Date(dep.when) - Date.now()) / 2 / minute)
+		const i = Math.floor((new Date(dep.when) - Date.now()) / 2 / minute) + timeToStation
 		return setColor(colors[i] || 'question')
 	})
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const colors = [
 const minute = 1000 * 60
 
 module.exports = (from, to, timeToStation = 0) => {
-	let options = {}
+	const options = {}
 
 	if (Number.isNaN(timeToStation)) throw new Error('invalid when parameter')
 	options.when = Date.now() + timeToStation * minute
@@ -32,7 +32,7 @@ module.exports = (from, to, timeToStation = 0) => {
 		// Comment left in for future debugging as required
 		// console.log(`Next departure is at ${dep.when}, in ${minutesToDeparture} minutes time. This gives ${spareTimeBeforeDeparture} minutes spare, after spending ${timeToStation} minutes on the way to the station.`)
 
-		let timeColor = colors[spareTimeBeforeDeparture / 2]
+		const timeColor = colors[spareTimeBeforeDeparture / 2]
 		return setColor(timeColor || 'question')
 	})
 }

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,12 @@ npm install -g vbb-anybar
 `vbb-anybar` needs the station where you want to catch the train and the direction, which is just the next station your train will pass. You can find them using [`vbb-stations-cli`](https://github.com/derhuerst/vbb-stations-cli#vbb-stations-cli). To set them, run the following:
 
 ```shell
-vbb-anybar init <station-id> <next-station-id>
+vbb-anybar init <station-id> <next-station-id> [<time-to-station>]
 ```
 
 From now on, if you call `vbb-anybar` (without any arguments), it will talk to the AnyBar app and set a color that tells you when to leave. You would usually run this every few seconds.
+
+time-to-station is an optional argument which allows you to configure a time (in minutes) for how long it takes you to get to the station. The color telling you when to leave will calculate with this time as well.
 
 
 ## API
@@ -33,7 +35,7 @@ From now on, if you call `vbb-anybar` (without any arguments), it will talk to t
 ```
 Usage:
     vbb-anybar
-    vbb-anybar init <station-id> <next-station-id>
+    vbb-anybar init <station-id> <next-station-id> [<time-to-station>]
 ```
 
 


### PR DESCRIPTION
Added a 'time-to-station' configuration possibility allowing users to specify in minutes how long it takes them to walk to (or indeed drive to, swim to, fly to, etc.) their departure station